### PR TITLE
Corrigindo click duplo

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 //import liraries
 import React, { Component } from 'react';
-import { Text, StyleSheet, TouchableOpacity, View, FlatList, TextInput, Dimensions, Animated, Platform } from 'react-native';
+import { Text, StyleSheet, TouchableOpacity, View, FlatList, TextInput, Dimensions, Animated, Platform, Keyboard } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import Modal from 'react-native-modal';
 import Button from './lib/Button';
@@ -67,6 +67,19 @@ class Select2 extends Component {
         return defaultFontName ? { fontFamily: defaultFontName } : {};
     }
 
+
+    handleConfirm() {
+        let { onSelect } = this.props;
+        let { selectedItem } = this.state;
+        let selectedIds = [], selectedObjectItems = [];
+        selectedItem.map(item => {
+            selectedIds.push(item.id);
+            selectedObjectItems.push(item);
+        })
+        onSelect && onSelect(selectedIds, selectedObjectItems);
+        this.setState({ show: false, keyword: '', preSelectedItem: selectedItem });
+    }
+
     cancelSelection() {
         let { data, preSelectedItem } = this.state;
         data.map(item => {
@@ -95,6 +108,11 @@ class Select2 extends Component {
         data.map(item => {
             if (item.checked) selectedItem.push(item);
         })
+        if(isSelectSingle && item.checked) {
+            Keyboard.dismiss()
+            this.closeModal()
+            this.handleConfirm()
+        }
         this.setState({ data, selectedItem });
     }
     keyExtractor = (item, idx) => idx.toString();
@@ -128,11 +146,11 @@ class Select2 extends Component {
 
     render() {
         let {
-            style, modalStyle, title, onSelect, onRemoveItem, popupTitle, colorTheme,
+            style, modalStyle, title, onRemoveItem, popupTitle, colorTheme,
             isSelectSingle, cancelButtonText, selectButtonText, searchPlaceHolderText,
             selectedTitleStyle, buttonTextStyle, buttonStyle, showSearchBox
         } = this.props;
-        let { show, selectedItem, preSelectedItem, inputRef } = this.state;
+        let { show, preSelectedItem, inputRef } = this.state;
         return (
             <TouchableOpacity
                 onPress={this.showModal}
@@ -187,6 +205,7 @@ class Select2 extends Component {
                                 : null
                         }
                         <FlatList
+                            keyboardShouldPersistTaps="handled"
                             style={styles.listOption}
                             data={this.dataRender || []}
                             keyExtractor={this.keyExtractor}
@@ -205,21 +224,15 @@ class Select2 extends Component {
                                 backgroundColor='#fff'
                                 textStyle={buttonTextStyle}
                                 style={[styles.button, buttonStyle, { marginRight: 5, marginLeft: 10, borderWidth: 1, borderColor: colorTheme }]} />
+                            {!isSelectSingle &&
                             <Button
                                 defaultFont={this.defaultFont}
-                                onPress={() => {
-                                    let selectedIds = [], selectedObjectItems = [];
-                                    selectedItem.map(item => {
-                                        selectedIds.push(item.id);
-                                        selectedObjectItems.push(item);
-                                    })
-                                    onSelect && onSelect(selectedIds, selectedObjectItems);
-                                    this.setState({ show: false, keyword: '', preSelectedItem: selectedItem });
-                                }}
+                                onPress={this.handleConfirm}
                                 title={selectButtonText}
                                 backgroundColor={colorTheme}
                                 textStyle={buttonTextStyle}
                                 style={[styles.button, buttonStyle, { marginLeft: 5, marginRight: 10 }]} />
+                            }
                         </View>
                     </Animated.View>
                 </Modal>


### PR DESCRIPTION
Corrigindo click duplo para selecionar um motorista ao adicionar a propriedade `keyboardShouldPersistTaps` como `handle` no Flatlist

Outras alterações:

Quando for `singleSelect` o botão de enviar desaparece e ao selecionar um item, a escolha é confirmada e o modal fechado

Quando for `singleSelect`  só vai confirmar a escolha de um item quando o item selecionado receber check como true, não como false, ou seja o modal fecha apenas quando um item é selecionado não quando ele deixar de ser selecionado